### PR TITLE
Correctly deal with empty mclag values

### DIFF
--- a/configdb/configdb.go
+++ b/configdb/configdb.go
@@ -260,8 +260,8 @@ func getInterfaces(ports []values.Port, bgpPorts []string) map[string]Interface 
 	return interfaces
 }
 
-func getMCLAGDomains(mclag *values.MCLAG) map[string]MCLAGDomain {
-	if mclag == nil {
+func getMCLAGDomains(mclag values.MCLAG) map[string]MCLAGDomain {
+	if mclag.KeepaliveVLAN == "" {
 		return nil
 	}
 
@@ -275,8 +275,8 @@ func getMCLAGDomains(mclag *values.MCLAG) map[string]MCLAGDomain {
 	}
 }
 
-func getMCLAGInterfaces(mclag *values.MCLAG) map[string]MCLAGInterface {
-	if mclag == nil {
+func getMCLAGInterfaces(mclag values.MCLAG) map[string]MCLAGInterface {
+	if mclag.KeepaliveVLAN == "" {
 		return nil
 	}
 
@@ -291,8 +291,8 @@ func getMCLAGInterfaces(mclag *values.MCLAG) map[string]MCLAGInterface {
 	return mclagInterfaces
 }
 
-func getMCLAGUniqueIPs(mclag *values.MCLAG) map[string]MCLAGUniqueIP {
-	if mclag == nil {
+func getMCLAGUniqueIPs(mclag values.MCLAG) map[string]MCLAGUniqueIP {
+	if mclag.KeepaliveVLAN == "" {
 		return nil
 	}
 

--- a/tests/2/sonic-config.yaml
+++ b/tests/2/sonic-config.yaml
@@ -13,6 +13,7 @@ hostname: leaf01
 lldp_hello_time: 10
 loopback_address: 10.7.7.7
 
+mclag: {}
 mgmtif_gateway: 10.7.10.1
 mgmtif_ip: 10.7.10.2
 mgmt_vrf: false
@@ -41,6 +42,7 @@ ports:
 
 ports_default_fec: none
 ports_default_mtu: 9000
+sag: {}
 
 ssh_sourceranges:
   - 10.1.23.1/30

--- a/values/values.go
+++ b/values/values.go
@@ -67,7 +67,7 @@ type Values struct {
 	Interconnects           map[string]Interconnect `yaml:"interconnects"`
 	LLDPHelloTime           int                     `yaml:"lldp_hello_time"`
 	LoopbackAddress         string                  `yaml:"loopback_address"`
-	MCLAG                   *MCLAG                  `yaml:"mclag"`
+	MCLAG                   MCLAG                   `yaml:"mclag"`
 	MgmtIfGateway           string                  `yaml:"mgmtif_gateway"`
 	MgmtIfIP                string                  `yaml:"mgmtif_ip"`
 	MgmtVRF                 bool                    `yaml:"mgmt_vrf"`


### PR DESCRIPTION
## Description

Otherwise, when an empty object is passed as a default for `mclag` a nonsensical `MCLAG` object is created in the `config_db.json`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
