### PR TITLE
Remove vlan_members variable and always add members

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Result:
 }
 ```
 
-### vlans and vlan_members
+### vlans
 
 Example:
 
@@ -546,8 +546,6 @@ vlans:
     untagged_ports:
       - PortChannel11
     vrf: Vrf45
-
-vlan_members: true
 ```
 
 Result:

--- a/configdb/configdb.go
+++ b/configdb/configdb.go
@@ -94,7 +94,7 @@ func GenerateConfigDB(input *values.Values, platform *p.Platform, currentDeviceM
 		SAG:                getSAG(input.SAG),
 		VLANs:              getVLANs(input.VLANs),
 		VLANInterfaces:     getVLANInterfaces(input.VLANs),
-		VLANMembers:        getVLANMembers(input.VLANs, input.VLANMembers),
+		VLANMembers:        getVLANMembers(input.VLANs),
 		VRFs:               getVRFs(input.Interconnects, input.Ports, input.VLANs),
 		VXLANEVPN:          vxlanevpn,
 		VXLANTunnels:       vxlanTunnel,
@@ -489,22 +489,16 @@ func getVLANInterfaces(vlans []values.VLAN) map[string]VLANInterface {
 		}
 
 		vlanInterfaces["Vlan"+vlan.ID] = vlanInterface
-
 		if vlan.IP == "" {
 			continue
 		}
-
 		vlanInterfaces["Vlan"+vlan.ID+"|"+vlan.IP] = VLANInterface{}
 	}
 
 	return vlanInterfaces
 }
 
-func getVLANMembers(vlans []values.VLAN, addVlanMembers bool) map[string]VLANMember {
-	if !addVlanMembers {
-		return nil
-	}
-
+func getVLANMembers(vlans []values.VLAN) map[string]VLANMember {
 	vlanMembers := make(map[string]VLANMember)
 
 	for _, vlan := range vlans {

--- a/tests/1/sonic-config.yaml
+++ b/tests/1/sonic-config.yaml
@@ -101,8 +101,6 @@ vlans:
     vrf: Vrf45
   - id: 4001
 
-vlan_members: true
-
 vteps:
   - vni: 103999
     vlan: Vlan3999

--- a/tests/2/sonic-config.yaml
+++ b/tests/2/sonic-config.yaml
@@ -55,5 +55,3 @@ vlans:
       - 10.9.8.6
     ip: 10.9.7.0
   - id: 4001
-
-vlan_members: true

--- a/tests/3/sonic-config.yaml
+++ b/tests/3/sonic-config.yaml
@@ -46,8 +46,6 @@ vlans:
       - Ethernet47
   - id: 4009
 
-vlan_members: true
-
 vteps:
   - vni: 104009
     vlan: Vlan4009

--- a/values/values.go
+++ b/values/values.go
@@ -123,9 +123,8 @@ type VLAN struct {
 }
 
 type VTEP struct {
-	Comment string `yaml:"comment"`
-	VNI     string `yaml:"vni"`
-	VLAN    string `yaml:"vlan"`
+	VNI  string `yaml:"vni"`
+	VLAN string `yaml:"vlan"`
 }
 
 func UnmarshalValues(in []byte) (*Values, error) {

--- a/values/values.go
+++ b/values/values.go
@@ -108,7 +108,6 @@ type Values struct {
 	Ports                   Ports                   `yaml:"ports"`
 	SAG                     SAG                     `yaml:"sag"`
 	SSHSourceranges         []string                `yaml:"ssh_sourceranges"`
-	VLANMembers             bool                    `yaml:"vlan_members"`
 	VLANs                   []VLAN                  `yaml:"vlans"`
 	VTEPs                   []VTEP                  `yaml:"vteps"`
 }


### PR DESCRIPTION
## Description

This variable was a remainder from the template and doesn't really make sense. If there are tagged or untagged ports added to the vlan dictionary they should be added to the config.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
