### PR TITLE
Add switch to add VTEP with no VXLAN tunnel maps configured

### DIFF
--- a/configdb/configdb.go
+++ b/configdb/configdb.go
@@ -268,15 +268,14 @@ func getLLDP(interval int) *LLDP {
 }
 
 func getLoopbackInterface(loopback string) map[string]struct{} {
-	loopbackInterface := map[string]struct{}{
-		"Loopback0": {},
+	if loopback == "" {
+		return nil
 	}
 
-	if loopback != "" {
-		loopbackInterface[fmt.Sprintf("Loopback0|%s/32", loopback)] = struct{}{}
+	return map[string]struct{}{
+		"Loopback0":                              {},
+		fmt.Sprintf("Loopback0|%s/32", loopback): {},
 	}
-
-	return loopbackInterface
 }
 
 func getMCLAGDomains(mclag values.MCLAG) map[string]MCLAGDomain {
@@ -564,7 +563,11 @@ func getVRFs(interconnects map[string]values.Interconnect, ports values.Ports, v
 }
 
 func getVXLAN(vtep values.VTEP, loopback string) (*VXLANEVPN, map[string]VXLANTunnel, VXLANTunnelMap) {
-	if !vtep.AddVTEP && len(vtep.VXLANTunnelMaps) == 0 {
+	if !vtep.Enabled && len(vtep.VXLANTunnelMaps) == 0 {
+		return nil, nil, nil
+	}
+
+	if loopback == "" {
 		return nil, nil, nil
 	}
 

--- a/tests/1/sonic-config.yaml
+++ b/tests/1/sonic-config.yaml
@@ -101,6 +101,7 @@ vlans:
     vrf: Vrf45
   - id: 4001
 
-vteps:
-  - vni: 103999
-    vlan: Vlan3999
+vtep:
+  vxlan_tunnel_maps:
+    - vni: 103999
+      vlan: Vlan3999

--- a/tests/2/expected.json
+++ b/tests/2/expected.json
@@ -522,5 +522,15 @@
     "Vlan4000": {},
     "Vlan4000|10.9.7.0": {},
     "Vlan4001": {}
+  },
+  "VXLAN_EVPN_NVO": {
+    "nvo": {
+      "source_vtep": "vtep"
+    }
+  },
+  "VXLAN_TUNNEL": {
+    "vtep": {
+      "src_ip": "10.7.7.7"
+    }
   }
 }

--- a/tests/2/sonic-config.yaml
+++ b/tests/2/sonic-config.yaml
@@ -55,3 +55,6 @@ vlans:
       - 10.9.8.6
     ip: 10.9.7.0
   - id: 4001
+
+vtep:
+  add_vtep: true

--- a/tests/2/sonic-config.yaml
+++ b/tests/2/sonic-config.yaml
@@ -57,4 +57,4 @@ vlans:
   - id: 4001
 
 vtep:
-  add_vtep: true
+  enabled: true

--- a/tests/3/expected.json
+++ b/tests/3/expected.json
@@ -187,9 +187,6 @@
       "vrf_name": "VrfInternet"
     }
   },
-  "LOOPBACK_INTERFACE": {
-    "Loopback0": {}
-  },
   "MGMT_PORT": {
     "eth0": {
       "admin_status": "up",
@@ -719,13 +716,5 @@
   },
   "VRF": {
     "VrfInternet": {}
-  },
-  "VXLAN_EVPN_NVO": {
-    "nvo": {
-      "source_vtep": "vtep"
-    }
-  },
-  "VXLAN_TUNNEL": {
-    "vtep": {}
   }
 }

--- a/tests/3/expected.json
+++ b/tests/3/expected.json
@@ -188,8 +188,7 @@
     }
   },
   "LOOPBACK_INTERFACE": {
-    "Loopback0": {},
-    "Loopback0|10.0.0.2/32": {}
+    "Loopback0": {}
   },
   "MGMT_PORT": {
     "eth0": {
@@ -727,14 +726,6 @@
     }
   },
   "VXLAN_TUNNEL": {
-    "vtep": {
-      "src_ip": "10.0.0.2"
-    }
-  },
-  "VXLAN_TUNNEL_MAP": {
-    "vtep|map_104009_Vlan4009": {
-      "vlan": "Vlan4009",
-      "vni": "104009"
-    }
+    "vtep": {}
   }
 }

--- a/tests/3/sonic-config.yaml
+++ b/tests/3/sonic-config.yaml
@@ -1,4 +1,3 @@
----
 bgp_ports:
   - Ethernet0
   - Ethernet1
@@ -6,7 +5,6 @@ bgp_ports:
 docker_routing_config_mode: split
 frr_mgmt_framework_config: true
 hostname: mgmtspine
-loopback_address: 10.0.0.2
 mgmt_vrf: false
 
 ntp:
@@ -46,6 +44,5 @@ vlans:
       - Ethernet47
   - id: 4009
 
-vteps:
-  - vni: 104009
-    vlan: Vlan4009
+vtep:
+  add_vtep: true

--- a/tests/3/sonic-config.yaml
+++ b/tests/3/sonic-config.yaml
@@ -45,4 +45,4 @@ vlans:
   - id: 4009
 
 vtep:
-  add_vtep: true
+  enabled: true

--- a/values/values.go
+++ b/values/values.go
@@ -51,15 +51,15 @@ type MgmtInterface struct {
 }
 
 type NTP struct {
-	SrcInterface string   `yaml:"src_interface"`
 	Servers      []string `yaml:"servers"`
+	SrcInterface string   `yaml:"src_interface"`
 	VRF          string   `yaml:"vrf"`
 }
 
 type Port struct {
 	Autoneg AutonegMode `yaml:"autoneg"`
-	IPs     []string    `yaml:"ips"`
 	FECMode FECMode     `yaml:"fec"`
+	IPs     []string    `yaml:"ips"`
 	MTU     int         `yaml:"mtu"`
 	Name    string      `yaml:"name"`
 	Speed   int         `yaml:"speed"`
@@ -109,7 +109,7 @@ type Values struct {
 	SAG                     SAG                     `yaml:"sag"`
 	SSHSourceranges         []string                `yaml:"ssh_sourceranges"`
 	VLANs                   []VLAN                  `yaml:"vlans"`
-	VTEPs                   []VTEP                  `yaml:"vteps"`
+	VTEP                    VTEP                    `yaml:"vtep"`
 }
 
 type VLAN struct {
@@ -123,6 +123,11 @@ type VLAN struct {
 }
 
 type VTEP struct {
+	AddVTEP         bool             `yaml:"add_vtep"`
+	VXLANTunnelMaps []VXLANTunnelMap `yaml:"vxlan_tunnel_maps"`
+}
+
+type VXLANTunnelMap struct {
 	VNI  string `yaml:"vni"`
 	VLAN string `yaml:"vlan"`
 }

--- a/values/values.go
+++ b/values/values.go
@@ -123,7 +123,7 @@ type VLAN struct {
 }
 
 type VTEP struct {
-	AddVTEP         bool             `yaml:"add_vtep"`
+	Enabled         bool             `yaml:"enabled"`
 	VXLANTunnelMaps []VXLANTunnelMap `yaml:"vxlan_tunnel_maps"`
 }
 


### PR DESCRIPTION
## Description

As discussed with @robertvolkmann it is sometimes necessary to configure VTEP on a switch without adding VXLAN tunnel maps. This PR adds a toggle which can be used like this:

```yaml
vtep:
  enabled: true
```

Such configuration will add NVO and VXLAN tunnel configs to the config_db.json and leave the VXLAN tunnel maps empty.
Apart from that I cleaned up some parts of the code that are unrelated but too small for an additional PR.

@robertvolkmann @mwindower if you have a different opinion on what should be configurable and how, please comment.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
