### PR TITLE
Pass device metadate as values instead of reading current config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ Result:
 
 For each breakout also the correspondig ports entries are added.
 
+### device_metadata
+
+Example:
+
+```yaml
+device_metadata:
+  hwsku: Accton-AS7726-32X
+  mac: aa:aa:aa:aa:aa:aa
+  platform: x86_64-accton_as7726_32x-r0
+```
+
+Result:
+
+```json
+{
+  "DEVICE_METADATA": {
+    "localhost": {
+      "hwsku": "Accton-AS7726-32X",
+      "mac": "aa:aa:aa:aa:aa:aa",
+      "platform": "x86_64-accton_as7726_32x-r0"
+    }
+  }
+}
+```
+
 ### docker_routing_config_mode
 
 Can be one of `separated`, `split`, `split-unified`, `unified`.

--- a/configdb/configdb.go
+++ b/configdb/configdb.go
@@ -43,7 +43,7 @@ type ConfigDB struct {
 	VXLANTunnelMap     VXLANTunnelMap              `json:"VXLAN_TUNNEL_MAP,omitempty"`
 }
 
-func GenerateConfigDB(input *values.Values, platform *p.Platform, currentDeviceMetadata DeviceMetadata) (*ConfigDB, error) {
+func GenerateConfigDB(input *values.Values, platform *p.Platform, currentDeviceMetadata values.DeviceMetadata) (*ConfigDB, error) {
 	if input == nil {
 		return nil, fmt.Errorf("no input values provided")
 	}
@@ -168,16 +168,16 @@ func getACLRulesAndTables(sourceRanges []string) (map[string]ACLRule, map[string
 	return rules, tables
 }
 
-func getDeviceMetadata(input *values.Values, currentMetadata DeviceMetadata) (*DeviceMetadata, error) {
-	if currentMetadata.Localhost.Platform == "" {
+func getDeviceMetadata(input *values.Values, currentMetadata values.DeviceMetadata) (*DeviceMetadata, error) {
+	if currentMetadata.Platform == "" {
 		return nil, fmt.Errorf("missing platform from current device metadata")
 	}
 
-	if currentMetadata.Localhost.HWSKU == "" {
+	if currentMetadata.HWSKU == "" {
 		return nil, fmt.Errorf("missing hwsku from current device metadata")
 	}
 
-	if currentMetadata.Localhost.MAC == "" {
+	if currentMetadata.MAC == "" {
 		return nil, fmt.Errorf("missing mac from current device metadata")
 	}
 
@@ -186,9 +186,9 @@ func getDeviceMetadata(input *values.Values, currentMetadata DeviceMetadata) (*D
 			DockerRoutingConfigMode: DockerRoutingConfigMode(input.DockerRoutingConfigMode),
 			FRRMgmtFrameworkConfig:  strconv.FormatBool(input.FRRMgmtFrameworkConfig),
 			Hostname:                input.Hostname,
-			HWSKU:                   currentMetadata.Localhost.HWSKU,
-			MAC:                     currentMetadata.Localhost.MAC,
-			Platform:                currentMetadata.Localhost.Platform,
+			HWSKU:                   currentMetadata.HWSKU,
+			MAC:                     currentMetadata.MAC,
+			Platform:                currentMetadata.Platform,
 			RouterType:              "LeafRouter",
 		},
 	}, nil

--- a/tests/1/current-config_db.json
+++ b/tests/1/current-config_db.json
@@ -1,9 +1,0 @@
-{
-  "DEVICE_METADATA": {
-    "localhost": {
-      "hwsku": "Accton-AS7726-32X",
-      "mac": "aa:aa:aa:aa:aa:aa",
-      "platform": "x86_64-accton_as7726_32x-r0"
-    }
-  }
-}

--- a/tests/1/sonic-config.yaml
+++ b/tests/1/sonic-config.yaml
@@ -5,6 +5,11 @@ bgp_ports:
 breakouts:
   Ethernet0: 4x25G
 
+device_metadata:
+  hwsku: Accton-AS7726-32X
+  mac: aa:aa:aa:aa:aa:aa
+  platform: x86_64-accton_as7726_32x-r0
+
 docker_routing_config_mode: split
 
 features:

--- a/tests/2/current-config_db.json
+++ b/tests/2/current-config_db.json
@@ -1,9 +1,0 @@
-{
-  "DEVICE_METADATA": {
-    "localhost": {
-      "hwsku": "Accton-AS7726-32X",
-      "mac": "aa:aa:aa:aa:aa:aa",
-      "platform": "x86_64-accton_as7726_32x-r0"
-    }
-  }
-}

--- a/tests/2/sonic-config.yaml
+++ b/tests/2/sonic-config.yaml
@@ -5,6 +5,11 @@ bgp_ports:
 breakouts:
   Ethernet0: 4x25G
 
+device_metadata:
+  hwsku: Accton-AS7726-32X
+  mac: aa:aa:aa:aa:aa:aa
+  platform: x86_64-accton_as7726_32x-r0
+
 docker_routing_config_mode: split
 features: {}
 frr_mgmt_framework_config: false

--- a/tests/3/current-config_db.json
+++ b/tests/3/current-config_db.json
@@ -1,9 +1,0 @@
-{
-  "DEVICE_METADATA": {
-    "localhost": {
-      "hwsku": "Accton-AS4630-54TE",
-      "mac": "aa:aa:aa:aa:aa:aa",
-      "platform": "x86_64-accton_as4630_54te-r0"
-    }
-  }
-}

--- a/tests/3/sonic-config.yaml
+++ b/tests/3/sonic-config.yaml
@@ -2,6 +2,11 @@ bgp_ports:
   - Ethernet0
   - Ethernet1
 
+device_metadata:
+  hwsku: Accton-AS4630-54TE
+  mac: aa:aa:aa:aa:aa:aa
+  platform: x86_64-accton_as4630_54te-r0
+
 docker_routing_config_mode: split
 frr_mgmt_framework_config: true
 hostname: mgmtspine

--- a/tests/4/current-config_db.json
+++ b/tests/4/current-config_db.json
@@ -1,9 +1,0 @@
-{
-  "DEVICE_METADATA": {
-    "localhost": {
-      "hwsku": "Accton-AS4625-54T",
-      "mac": "aa:aa:aa:aa:aa:aa",
-      "platform": "x86_64-accton_as4625_54t-r0"
-    }
-  }
-}

--- a/tests/4/sonic-config.yaml
+++ b/tests/4/sonic-config.yaml
@@ -1,3 +1,8 @@
+device_metadata:
+  hwsku: Accton-AS4625-54T
+  mac: aa:aa:aa:aa:aa:aa
+  platform: x86_64-accton_as4625_54t-r0
+
 docker_routing_config_mode: split
 frr_mgmt_framework_config: false
 hostname: leaf01

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,7 +3,7 @@
 for i in 1 2 3 4
 do
   test_dir=$(pwd)/tests/$i
-  docker run --rm -v $(pwd)/tests/device:/usr/share/sonic/device:ro -v $test_dir:/sonic sonic-configdb-utils:local generate -c /sonic/current-config_db.json -i /sonic/sonic-config.yaml -o /sonic/config_db.json
+  docker run --rm -v $(pwd)/tests/device:/usr/share/sonic/device:ro -v $test_dir:/sonic sonic-configdb-utils:local generate -i /sonic/sonic-config.yaml -o /sonic/config_db.json
   diff --color=always $test_dir/expected.json $test_dir/config_db.json
 
   if [[ $? != 0 ]]; then

--- a/values/values.go
+++ b/values/values.go
@@ -9,6 +9,12 @@ const (
 	AutonegModeOff AutonegMode = "off"
 )
 
+type DeviceMetadata struct {
+	HWSKU    string `yaml:"hwsku"`
+	MAC      string `yaml:"mac"`
+	Platform string `yaml:"platform"`
+}
+
 type DockerRoutingConfigMode string
 
 const (
@@ -92,6 +98,7 @@ type SAG struct {
 type Values struct {
 	BGPPorts                []string                `yaml:"bgp_ports"`
 	Breakouts               map[string]string       `yaml:"breakouts"`
+	DeviceMetadata          DeviceMetadata          `yaml:"device_metadata"`
 	DockerRoutingConfigMode DockerRoutingConfigMode `yaml:"docker_routing_config_mode"`
 	Features                map[string]Feature      `yaml:"features"`
 	FRRMgmtFrameworkConfig  bool                    `yaml:"frr_mgmt_framework_config"`


### PR DESCRIPTION
## Description

This will eliminate the need to have a `config_db.json` with valid device metadata. Consumers will have to pass the device metadata as input values instead.

Closes #6.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
